### PR TITLE
fix: install argus from crates.io in review workflow

### DIFF
--- a/.github/workflows/argus-review.yml
+++ b/.github/workflows/argus-review.yml
@@ -15,17 +15,19 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
       - name: Install Argus
-        run: |
-          curl -sSL https://github.com/Meru143/argus/releases/latest/download/argus-x86_64-unknown-linux-gnu.tar.gz | tar xz
-          sudo mv argus /usr/local/bin/
+        run: cargo install argus-ai --locked
 
       - name: Run Review
         env:
-          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           argus review \
+            --provider gemini \
             --diff origin/${{ github.base_ref }}..HEAD \
             --pr ${{ github.repository }}#${{ github.event.pull_request.number }} \
             --post-comments \


### PR DESCRIPTION
The Argus Code Review workflow was trying to download a binary from GitHub Releases that doesn't exist. Changed to `cargo install argus-ai --locked` from crates.io.

**Still needed:** Add `OPENAI_API_KEY` as a repository secret for the review to actually run.