### PR TITLE
fix: use dynamic version in MCP server info test

### DIFF
--- a/crates/argus-mcp/tests/integration.rs
+++ b/crates/argus-mcp/tests/integration.rs
@@ -25,7 +25,7 @@ fn server_info_is_correct() {
     let info = server.get_info();
 
     assert_eq!(info.server_info.name, "argus");
-    assert_eq!(info.server_info.version, "0.2.2");
+    assert_eq!(info.server_info.version, env!("CARGO_PKG_VERSION"));
     assert!(info.instructions.is_some());
     let instructions = info.instructions.unwrap();
     assert!(instructions.contains("analyze_diff"));


### PR DESCRIPTION
The test hardcoded "0.2.2" which breaks on version bumps. Now uses env!("CARGO_PKG_VERSION") so it always matches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated version assertion in integration tests to dynamically use the package version at compile time instead of a hard-coded value, ensuring tests remain accurate across releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->