### PR TITLE
feat: local LLM support (Ollama)

### DIFF
--- a/crates/argus-review/src/llm.rs
+++ b/crates/argus-review/src/llm.rs
@@ -456,10 +456,7 @@ impl LlmClient {
     }
 
     async fn chat_ollama(&self, messages: Vec<ChatMessage>) -> Result<String, ArgusError> {
-        let base_url = self
-            .base_url
-            .as_deref()
-            .unwrap_or("http://localhost:11434");
+        let base_url = self.base_url.as_deref().unwrap_or("http://localhost:11434");
         let url = format!("{base_url}/api/chat");
 
         let body = serde_json::json!({


### PR DESCRIPTION
Adds support for local LLMs via Ollama.

- Usage: Set  in .
- Default model: .
- Default URL: .
- Endpoints: Uses .
- No API key required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ollama as a new supported LLM provider for chat operations.

* **Tests**
  * Added comprehensive test coverage for Ollama provider integration, request formatting, and response parsing.

* **Documentation**
  * Updated documentation to reflect Ollama endpoints and provider configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->