### PR TITLE
fix: remove invalid --diff arg from review workflow

### DIFF
--- a/.github/workflows/argus-review.yml
+++ b/.github/workflows/argus-review.yml
@@ -35,7 +35,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           argus review \
-            --diff origin/${{ github.base_ref }}..HEAD \
             --pr ${{ github.repository }}#${{ github.event.pull_request.number }} \
             --post-comments \
             --fail-on bug


### PR DESCRIPTION
The `argus review` command fails when both `--diff` and `--pr` are provided, or because `--diff` is not a valid flag for the `review` subcommand (it uses positional args or stdin).

This PR removes the `--diff` argument from the GitHub Action workflow, allowing `--pr` to handle diff retrieval internally.