### PR TITLE
docs: add homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ git diff HEAD~1 | npx argus-ai review --repo .
 
 ## Install
 
+### Homebrew (macOS/Linux)
+
+```bash
+brew tap Meru143/argus
+brew install argus
+```
+
 ### npm (Recommended)
 
 ```bash


### PR DESCRIPTION
Adds instructions for installing Argus via the new Homebrew tap: .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Homebrew installation instructions, providing users with an alternative installation method via package manager alongside the existing npm installation option. Both approaches are now available and fully supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->