### PR TITLE
fix: allow release-plz to trigger CI checks

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -38,7 +38,8 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use GH_PAT if set to trigger CI workflows, otherwise fallback to GITHUB_TOKEN
+          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       # Custom step: Sync version to NPM and Publish


### PR DESCRIPTION
Updates the release workflow to use `GH_PAT` if available. This allows the automated Release PRs to trigger CI workflows (tests, linting) automatically, removing the need for manual empty commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release workflow authentication configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->