### PR TITLE
Change release tag pattern to 'argus-ai-v*'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     tags:
-      - 'v*'
+      - 'argus-ai-v*'
 
 jobs:
   build:


### PR DESCRIPTION
## Context

Hi, I found argus couple of days back. I want to use it for my project [safe-ai-factory](https://github.com/JuroOravec/safe-ai-factory) (more info here https://safeaifactory.com).

I'm running agents inside Docker containers. Supposedly, even if running inside Docker with Linux, I still need to account for both `amd64` (Apple Silicon) and `arm64` (x64), architectures.

When I went to look for the built binaries, I couldn't find anything.

## Fix

[release-plz](https://github.com/release-plz/release-plz) uses cargo crate names in release / git tags. The main Cargo crate is `argus-ai`, so the git tags have format `argus-ai-vX.X.X`.

The problem was that the CI was expecting `vX.X.X` pattern, and so it never matched.

That's why there's no binaries included in the releases of argus-ai so far.

So the fix is simply to update the pattern. I did that in [my fork](https://github.com/JuroOravec/argus/commit/4939ea9a31af5d2d4abac70b14dc7fc2c6bcb825). 

I can confirm that upon creating release `argus-ai-v0.5.2-test`, it now contains the binaries. See here https://github.com/JuroOravec/argus/releases/tag/argus-ai-v0.5.2-test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD pipeline configuration for release workflow trigger patterns.

---

**Note:** This release contains infrastructure updates only. No user-facing features or functionality have been changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->