### PR TITLE
Fix release tag downloads and normalize provider base URLs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     tags:
-      - 'v*'
+      - 'argus-ai-v*'
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -228,6 +228,10 @@ Argus supports natural language custom rules. Create a file at `.argus/rules.md`
 | Anthropic | `provider = "anthropic"` | `claude-sonnet-4-5` | `ANTHROPIC_API_KEY` |
 | Ollama | `provider = "ollama"` | `llama3` | (None) |
 
+For custom provider endpoints, set `[llm].base_url`. OpenAI-compatible and Gemini
+base URLs can be provided either with or without the version suffix, for example
+`https://openrouter.ai/api` or `https://openrouter.ai/api/v1`.
+
 ### Embedding Providers
 
 | Provider | Config | Model | Env Variable |

--- a/crates/argus-review/src/llm.rs
+++ b/crates/argus-review/src/llm.rs
@@ -82,6 +82,20 @@ pub struct LlmClient {
 
 const MAX_ERROR_REASON_CHARS: usize = 320;
 
+fn versioned_base_url(
+    base_url: Option<&str>,
+    default_base_url: &str,
+    version_suffix: &str,
+) -> String {
+    let normalized = base_url.unwrap_or(default_base_url).trim_end_matches('/');
+
+    if normalized.ends_with(version_suffix) {
+        normalized.to_string()
+    } else {
+        format!("{normalized}{version_suffix}")
+    }
+}
+
 impl std::fmt::Debug for LlmClient {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("LlmClient")
@@ -195,8 +209,9 @@ impl LlmClient {
             )
         })?;
 
-        let base_url = self.base_url.as_deref().unwrap_or("https://api.openai.com");
-        let url = format!("{base_url}/v1/chat/completions");
+        let base_url =
+            versioned_base_url(self.base_url.as_deref(), "https://api.openai.com", "/v1");
+        let url = format!("{base_url}/chat/completions");
 
         let body = serde_json::json!({
             "model": self.model,
@@ -261,11 +276,9 @@ impl LlmClient {
             )
         })?;
 
-        let base_url = self
-            .base_url
-            .as_deref()
-            .unwrap_or("https://api.anthropic.com");
-        let url = format!("{base_url}/v1/messages");
+        let base_url =
+            versioned_base_url(self.base_url.as_deref(), "https://api.anthropic.com", "/v1");
+        let url = format!("{base_url}/messages");
 
         // Extract system message(s) and non-system messages
         let mut system_parts: Vec<String> = Vec::new();
@@ -368,13 +381,14 @@ impl LlmClient {
             )
         })?;
 
-        let base_url = self
-            .base_url
-            .as_deref()
-            .unwrap_or("https://generativelanguage.googleapis.com");
+        let base_url = versioned_base_url(
+            self.base_url.as_deref(),
+            "https://generativelanguage.googleapis.com",
+            "/v1beta",
+        );
 
         let url = format!(
-            "{base_url}/v1beta/models/{}:generateContent?key={api_key}",
+            "{base_url}/models/{}:generateContent?key={api_key}",
             self.model,
         );
 
@@ -801,6 +815,42 @@ mod tests {
         assert_eq!(merged[1].content, "reply");
         assert_eq!(merged[1].role, Role::Assistant);
         assert_eq!(merged[2].content, "third");
+    }
+
+    #[test]
+    fn versioned_base_url_appends_missing_suffix() {
+        assert_eq!(
+            versioned_base_url(
+                Some("https://api.openai.com"),
+                "https://api.openai.com",
+                "/v1"
+            ),
+            "https://api.openai.com/v1"
+        );
+    }
+
+    #[test]
+    fn versioned_base_url_keeps_existing_suffix() {
+        assert_eq!(
+            versioned_base_url(
+                Some("https://openrouter.ai/api/v1"),
+                "https://api.openai.com",
+                "/v1",
+            ),
+            "https://openrouter.ai/api/v1"
+        );
+    }
+
+    #[test]
+    fn versioned_base_url_trims_trailing_slash() {
+        assert_eq!(
+            versioned_base_url(
+                Some("https://generativelanguage.googleapis.com/v1beta/"),
+                "https://generativelanguage.googleapis.com",
+                "/v1beta",
+            ),
+            "https://generativelanguage.googleapis.com/v1beta"
+        );
     }
 
     #[test]

--- a/npm/install.js
+++ b/npm/install.js
@@ -6,6 +6,7 @@ const os = require("os");
 
 const VERSION = require("./package.json").version;
 const REPO = "Meru143/argus";
+const RELEASE_TAG_PREFIX = "argus-ai-v";
 
 const PLATFORM_MAP = {
   "darwin-x64": "argus-x86_64-apple-darwin.tar.gz",
@@ -20,7 +21,7 @@ function getPlatformKey() {
 }
 
 function getDownloadUrl(asset) {
-  return `https://github.com/${REPO}/releases/download/v${VERSION}/${asset}`;
+  return `https://github.com/${REPO}/releases/download/${RELEASE_TAG_PREFIX}${VERSION}/${asset}`;
 }
 
 function download(url) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -782,26 +782,24 @@ fn chrono_days_ago(days: i64) -> i64 {
 const DEFAULT_CONFIG: &str = r#"# Argus Configuration
 # See: https://github.com/Meru143/argus
 
-[review]
-# LLM provider (OpenAI-compatible endpoint)
-# api_base = "https://api.openai.com/v1"
+[llm]
+# provider = "openai"
+# base_url = "https://api.openai.com"
 # model = "gpt-4o"
-# max_findings = 5
 
-[review.noise]
+[review]
+# max_comments = 5
 # skip_patterns = ["*.lock", "*.min.js", "vendor/**"]
+# skip_extensions = ["snap", "lock"]
 # min_confidence = 90
 # include_suggestions = false
+# cross_file = true
 # self_reflection = true
 # self_reflection_score_threshold = 7
 
 [embedding]
 # provider = "voyage"
 # model = "voyage-code-3"
-
-[history]
-# since_days = 180
-# max_files_per_commit = 25
 
 # Custom review rules (injected into LLM prompt)
 # [[rules]]


### PR DESCRIPTION
## Summary
- align the release workflow with the repo's rgus-ai-v* tags
- update the npm installer to download binaries from the same tag prefix
- normalize provider base URLs so /v1 and /v1beta are only added when missing
- fix the generated .argus.toml template and README guidance to match the actual config schema

Closes #63
Supersedes #62