### PR TITLE
chore: release v0.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Argus are documented here.
 
+## [0.5.4](https://github.com/Meru143/argus/compare/argus-ai-v0.5.3...argus-ai-v0.5.4) - 2026-04-04
+
+### Other
+
+- fix argus doc command and font lint
+- Update docs/styles.css
+- Update docs/index.html
+- Update docs/index.html
+- Update docs/index.html
+- Update docs/styles.css
+- add custom landing page
+
 ## [0.5.3](https://github.com/Meru143/argus/compare/argus-ai-v0.5.2...argus-ai-v0.5.3) - 2026-03-26
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "argus-ai"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "argus-codelens",
  "argus-core",
@@ -140,7 +140,7 @@ dependencies = [
 
 [[package]]
 name = "argus-codelens"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "argus-core",
  "argus-repomap",
@@ -156,7 +156,7 @@ dependencies = [
 
 [[package]]
 name = "argus-core"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "miette",
  "serde",
@@ -167,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "argus-difflens"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "argus-core",
  "glob",
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "argus-gitpulse"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "argus-core",
  "git2",
@@ -187,7 +187,7 @@ dependencies = [
 
 [[package]]
 name = "argus-mcp"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "argus-codelens",
  "argus-core",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "argus-repomap"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "argus-core",
  "ignore",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "argus-review"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "argus-codelens",
  "argus-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 
 [workspace.package]
 edition = "2021"
-version = "0.5.3"
+version = "0.5.4"
 license = "MIT"
 description = "AI code review platform — your coding agent shouldn't grade its own homework"
 repository = "https://github.com/Meru143/argus"
@@ -32,13 +32,13 @@ targets = [
 ]
 
 [workspace.dependencies]
-argus-core = { path = "crates/argus-core", version = "0.5.3" }
-argus-repomap = { path = "crates/argus-repomap", version = "0.5.3" }
-argus-difflens = { path = "crates/argus-difflens", version = "0.5.3" }
-argus-codelens = { path = "crates/argus-codelens", version = "0.5.3" }
-argus-gitpulse = { path = "crates/argus-gitpulse", version = "0.5.3" }
-argus-review = { path = "crates/argus-review", version = "0.5.3" }
-argus-mcp = { path = "crates/argus-mcp", version = "0.5.3" }
+argus-core = { path = "crates/argus-core", version = "0.5.4" }
+argus-repomap = { path = "crates/argus-repomap", version = "0.5.4" }
+argus-difflens = { path = "crates/argus-difflens", version = "0.5.4" }
+argus-codelens = { path = "crates/argus-codelens", version = "0.5.4" }
+argus-gitpulse = { path = "crates/argus-gitpulse", version = "0.5.4" }
+argus-review = { path = "crates/argus-review", version = "0.5.4" }
+argus-mcp = { path = "crates/argus-mcp", version = "0.5.4" }
 
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION



## 🤖 New release

* `argus-core`: 0.5.3 -> 0.5.4
* `argus-repomap`: 0.5.3 -> 0.5.4
* `argus-difflens`: 0.5.3 -> 0.5.4
* `argus-codelens`: 0.5.3 -> 0.5.4
* `argus-gitpulse`: 0.5.3 -> 0.5.4
* `argus-review`: 0.5.3 -> 0.5.4
* `argus-mcp`: 0.5.3 -> 0.5.4
* `argus-ai`: 0.5.3 -> 0.5.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `argus-core`

<blockquote>

## [0.4.0](https://github.com/Meru143/argus/compare/argus-core-v0.3.2...argus-core-v0.4.0) - 2026-02-17

### Fixed

- *(test)* update stale doctest for max_diff_tokens default
- *(config)* increase default max_diff_tokens to 64k to reduce API calls
- *(review)* handle self-review permissions and improve error messages

### Other

- cargo fmt
</blockquote>

## `argus-repomap`

<blockquote>

## [0.3.0](https://github.com/Meru143/argus/compare/argus-repomap-v0.2.2...argus-repomap-v0.3.0) - 2026-02-16

### Added

- add PHP, Kotlin, Swift tree-sitter support (9→12 languages)
- self-reflection FP filtering, indicatif progress bars, 4 new languages ([#2](https://github.com/Meru143/argus/pull/2))
</blockquote>

## `argus-difflens`

<blockquote>

## [0.5.0](https://github.com/Meru143/argus/compare/argus-difflens-v0.4.1...argus-difflens-v0.5.0) - 2026-02-25

### Fixed

- resolve clippy cmp-owned in deleted file path check
- use normalized new path when detecting deleted files

### Other

- apply rustfmt for difflens parser tests
- add quoted-path diff fixture regression coverage
</blockquote>

## `argus-codelens`

<blockquote>

## [0.5.0](https://github.com/Meru143/argus/compare/argus-codelens-v0.4.1...argus-codelens-v0.5.0) - 2026-02-25

### Other

- Refactor vector_search to bounded top-k heap ([#56](https://github.com/Meru143/argus/pull/56))
</blockquote>


## `argus-review`

<blockquote>

## [0.5.3](https://github.com/Meru143/argus/compare/argus-review-v0.5.2...argus-review-v0.5.3) - 2026-03-26

### Other

- Fix release tags and normalize provider base URLs ([#64](https://github.com/Meru143/argus/pull/64))
</blockquote>

## `argus-mcp`

<blockquote>

## [0.5.0](https://github.com/Meru143/argus/compare/argus-mcp-v0.4.1...argus-mcp-v0.5.0) - 2026-02-25

### Other

- Harden MCP tool path resolution ([#54](https://github.com/Meru143/argus/pull/54))
</blockquote>

## `argus-ai`

<blockquote>

## [0.5.4](https://github.com/Meru143/argus/compare/argus-ai-v0.5.3...argus-ai-v0.5.4) - 2026-04-04

### Other

- fix argus doc command and font lint
- Update docs/styles.css
- Update docs/index.html
- Update docs/index.html
- Update docs/index.html
- Update docs/styles.css
- add custom landing page
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).