### PR TITLE
docs: fix argus doc command and font lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Argus is a local-first AI code review platform for teams that want an independen
 The short version is simple: your coding agent should not grade its own homework.
 
 ```bash
-git diff HEAD~1 | npx argus-ai review --repo .
+git diff HEAD~1 | npx argus review --repo .
 ```
 
 Live page: [merup.me/argus](https://merup.me/argus/)
@@ -29,13 +29,13 @@ Live page: [merup.me/argus](https://merup.me/argus/)
 
 ```bash
 # 1. Install via npm
-npx argus-ai init          # creates .argus.toml
+npx argus init             # creates .argus.toml
 
 # 2. Set your key (Gemini, Anthropic, or OpenAI)
 export GEMINI_API_KEY="your-key"
 
 # 3. Review your changes
-git diff HEAD~1 | npx argus-ai review --repo .
+git diff HEAD~1 | npx argus review --repo .
 ```
 
 ## Install
@@ -50,7 +50,7 @@ brew install argus
 ### npm (Recommended)
 
 ```bash
-npx argus-ai --help
+npx argus --help
 # or
 npm install -g argus-ai
 ```

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -31,7 +31,7 @@ body {
     radial-gradient(circle at top right, rgba(124, 156, 255, 0.18), transparent 30%),
     radial-gradient(circle at left center, rgba(255, 141, 102, 0.12), transparent 28%),
     linear-gradient(180deg, #0a0d12 0%, #0f1520 100%);
-  font-family: "Sora", system-ui, sans-serif;
+  font-family: Sora, system-ui, sans-serif;
 }
 
 body::before {


### PR DESCRIPTION
## Summary
- remove the unnecessary quotes around the single-word Sora font family in docs/styles.css
- update root README npm command examples to use the actual npm binary name, argus

## Verification
- rg found no remaining `font-family: "Sora"` or `npx argus-ai` in the touched files
- git diff --check
