### PR TITLE
docs: promote independent review headline

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -42,7 +42,7 @@
         <section class="hero">
           <div class="copy-card">
             <p class="eyebrow">Local-first AI review for serious codebases</p>
-            <h1>AI code review that actually understands your codebase.</h1>
+            <h1>Your coding agent should not grade its own homework.</h1>
             <p class="lede">
               Argus gives you an independent reviewer with structural maps, semantic
               search, git history, and diff-aware analysis, so the model reviewing the
@@ -90,7 +90,7 @@ recommendation:
         <section id="why" class="section">
           <div class="section-head">
             <p class="eyebrow">Why Argus</p>
-            <h2>Your coding agent should not grade its own homework.</h2>
+            <h2>AI code review that actually understands your codebase.</h2>
             <p>
               Most AI review workflows reuse the same shallow context that produced the
               patch. Argus takes the opposite stance: review should be independent,
@@ -175,9 +175,9 @@ recommendation:
           <div class="install-grid">
             <article class="install-card">
               <h3>npm</h3>
-              <pre><code>npx argus-ai init
+              <pre><code>npx argus init
 export GEMINI_API_KEY=your-key
-git diff HEAD~1 | npx argus-ai review --repo .</code></pre>
+git diff HEAD~1 | npx argus review --repo .</code></pre>
             </article>
             <article class="install-card">
               <h3>cargo</h3>


### PR DESCRIPTION
## Summary
- move the strongest positioning line into the hero headline
- move the former hero headline into the supporting section title
- fix the npm install example to use the real \rgus\ binary name

## Verification
- rendered the landing page locally with agent-browser and reviewed the updated hero

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated messaging and headlines to better emphasize Argus's AI code review capabilities
  * Revised installation and usage command examples for clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->