### PR TITLE
fix: align npm package usage across docs and launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Argus is a local-first AI code review platform for teams that want an independen
 The short version is simple: your coding agent should not grade its own homework.
 
 ```bash
-git diff HEAD~1 | npx argus review --repo .
+git diff HEAD~1 | npx argus-ai review --repo .
 ```
 
 Live page: [merup.me/argus](https://merup.me/argus/)
@@ -29,13 +29,13 @@ Live page: [merup.me/argus](https://merup.me/argus/)
 
 ```bash
 # 1. Install via npm
-npx argus init             # creates .argus.toml
+npx argus-ai init          # creates .argus.toml
 
 # 2. Set your key (Gemini, Anthropic, or OpenAI)
 export GEMINI_API_KEY="your-key"
 
 # 3. Review your changes
-git diff HEAD~1 | npx argus review --repo .
+git diff HEAD~1 | npx argus-ai review --repo .
 ```
 
 ## Install
@@ -50,7 +50,7 @@ brew install argus
 ### npm (Recommended)
 
 ```bash
-npx argus --help
+npx argus-ai --help
 # or
 npm install -g argus-ai
 ```
@@ -164,7 +164,7 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          argus-ai review \
+          argus review \
             --diff origin/${{ github.base_ref }}..HEAD \
             --pr ${{ github.repository }}#${{ github.event.pull_request.number }} \
             --post-comments \

--- a/docs/index.html
+++ b/docs/index.html
@@ -175,9 +175,9 @@ recommendation:
           <div class="install-grid">
             <article class="install-card">
               <h3>npm</h3>
-              <pre><code>npx argus init
+              <pre><code>npx argus-ai init
 export GEMINI_API_KEY=your-key
-git diff HEAD~1 | npx argus review --repo .</code></pre>
+git diff HEAD~1 | npx argus-ai review --repo .</code></pre>
             </article>
             <article class="install-card">
               <h3>cargo</h3>

--- a/npm/bin/argus
+++ b/npm/bin/argus
@@ -13,7 +13,7 @@ if (process.platform === "win32") {
 
 if (!fs.existsSync(binary)) {
   console.error(
-    "argus binary not found. Run `npm install` or `npx argus-ai` to download it."
+    "argus binary not found. Run `npm install` or `npx argus` to download it."
   );
   process.exit(1);
 }

--- a/npm/bin/argus
+++ b/npm/bin/argus
@@ -13,7 +13,7 @@ if (process.platform === "win32") {
 
 if (!fs.existsSync(binary)) {
   console.error(
-    "argus binary not found. Run `npm install` or `npx argus` to download it."
+    "argus binary not found. Run `npm install -g argus-ai` or `npx argus-ai` to download it."
   );
   process.exit(1);
 }


### PR DESCRIPTION
Restore one-off npm examples to use the actual package name (`npx argus-ai`), keep installed binary usage as `argus`, and update the npm launcher missing-binary message to point at `argus-ai`.