### PR TITLE
fix: tighten landing page proof layout

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -64,12 +64,13 @@
           </div>
 
           <aside class="terminal-card">
-            <div class="terminal-top">
-              <span></span>
-              <span></span>
-              <span></span>
-            </div>
-            <pre><code>$ git diff HEAD~1 | argus review --repo .
+            <div class="terminal-shell">
+              <div class="terminal-top">
+                <span></span>
+                <span></span>
+                <span></span>
+              </div>
+              <pre><code>$ git diff HEAD~1 | argus review --repo .
 
 review surface:
   repomap      loaded
@@ -84,6 +85,7 @@ confidence: high
 recommendation:
   add a test around token refresh and retry ordering
 </code></pre>
+            </div>
           </aside>
         </section>
 

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -99,6 +99,7 @@ pre {
   display: grid;
   grid-template-columns: minmax(0, 1.08fr) minmax(320px, 0.92fr);
   gap: 26px;
+  align-items: start;
   padding: 24px 0 44px;
 }
 
@@ -196,6 +197,17 @@ h1 {
   font-size: 0.9rem;
 }
 
+.terminal-card {
+  align-self: start;
+  padding: 12px;
+}
+
+.terminal-shell {
+  overflow: hidden;
+  border-radius: 20px;
+  background: linear-gradient(180deg, rgba(8, 12, 18, 0.82), rgba(8, 12, 18, 0.98));
+}
+
 .terminal-top {
   display: flex;
   gap: 8px;
@@ -216,7 +228,6 @@ h1 {
   margin: 0;
   padding: 18px 22px 24px;
   color: #edf2ff;
-  background: linear-gradient(180deg, rgba(8, 12, 18, 0.82), rgba(8, 12, 18, 0.98));
   line-height: 1.7;
   overflow-x: auto;
 }

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -199,6 +199,7 @@ h1 {
 
 .terminal-card {
   align-self: start;
+  height: fit-content;
   padding: 12px;
 }
 


### PR DESCRIPTION
## Summary
- trim the hero proof card so it does not stretch below the terminal content
- add an inner terminal shell so the proof block has intentional rounded clipping
- keep the headline-led hero balance while removing the dead space on the right

## Verification
- git diff --check
- browser screenshot review of the updated landing page


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved hero layout alignment for more consistent spacing and placement
  * Refreshed terminal appearance with rounded corners, adjusted sizing/padding, and updated gradient background
  * Better overflow handling: horizontal scrolling preserved while visual clipping and layout behave more predictably
  * Under-the-hood markup reorganized to support these visual improvements without changing content output
<!-- end of auto-generated comment: release notes by coderabbit.ai -->