### PR TITLE
fix(ci): fix binary releases and add musl Linux targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,18 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
+          # musl builds: statically linked, no GLIBC dependency. The
+          # *-unknown-linux-gnu binaries built on modern Ubuntu runners
+          # require GLIBC 2.39+, so they crash on older base images
+          # (Debian Bookworm ships GLIBC 2.36, Alpine uses musl, etc.).
+          # use_cross=true delegates to `cross`, which uses a Docker image
+          # with the full musl toolchain — no host-side apt acrobatics.
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            use_cross: true
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            use_cross: true
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: aarch64-apple-darwin
@@ -47,7 +59,16 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
-      - name: Build
+      - name: Install cross (musl targets)
+        if: matrix.use_cross
+        run: cargo install cross --locked
+
+      - name: Build (cross)
+        if: matrix.use_cross
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Build (cargo)
+        if: ${{ !matrix.use_cross }}
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package (unix)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,13 @@ permissions:
 on:
   push:
     tags:
-      - 'argus-ai-v*'
+      # release-plz reliably creates per-workspace-crate tags
+      # (`argus-core-v*`, `argus-mcp-v*`, etc.) on every release cycle. The
+      # `argus-ai-v*` tag for the root binary crate is no longer produced
+      # automatically; binary releases broke after v0.5.3 because this
+      # workflow was waiting for that pattern. Triggering on argus-core-v*
+      # restores the binary release flow.
+      - 'argus-core-v*'
 
 jobs:
   build:


### PR DESCRIPTION
WIP (fixing the desription


## Why

Update the repo to include built binaries in releases.


In the past I opened #62, but it seems it didn't fix the issue entirely. When you look at e.g. release of [argus-ai-v0.5.5](https://github.com/Meru143/argus/releases/tag/argus-ai-v0.5.5), there's still no binaries.


GitHub release pages for `argus-{core,review,mcp,…}-v0.5.4` and v0.5.5 ship source-only — the build matrix in `release.yml` never fires, so no binaries are attached. The last release with attached binaries was v0.5.3 (2026-03-26).

## Root cause

`release.yml` triggers on `argus-ai-v*` tags. release-plz, when invoked on the current workspace layout (root `[package]` named `argus-ai` with `version.workspace = true`, plus 7 members under `crates/`), reliably creates per-workspace-crate tags (`argus-core-v0.5.5`, `argus-mcp-v0.5.5`, etc.) but does NOT create an `argus-ai-v*` tag for the root binary crate. So the workflow trigger is stuck waiting for a pattern release-plz no longer produces.

Last `argus-ai-v*` tag from `github-actions[bot]`: `argus-ai-v0.5.3` (2026-03-26). Subsequent v0.5.4 and v0.5.5 release cycles produced only the per-crate tags.

## Fix proposed (commit 1)

Switch the workflow trigger from `argus-ai-v*` to `argus-core-v*`. `argus-core` is the foundational workspace member that's always part of every release-plz cycle, so its tag is reliably present. Binaries will attach to the `argus-core-v<version>` GitHub Release going forward.

## Alternative (not in this PR — happy to amend)

A more conservative fix is to add explicit release-plz configuration that tracks the root `argus-ai` package, restoring the original `argus-ai-v*` tag flow. Concretely, a `release-plz.toml` at repo root with:

```toml
[[package]]
name = "argus-ai"
publish = false  # binary-only; not a crates.io release


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to trigger on new tag naming scheme
  * Extended build support to include additional Linux architectures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->