### PR TITLE
fix(ci): restore binary releases + add musl Linux targets

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -28,7 +28,14 @@ jobs:
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # GH_PAT (with `repo` + `workflow` scopes) lets release-plz's bot
+          # tag pushes trigger downstream workflows like `Release` (release.yml).
+          # With plain GITHUB_TOKEN, GitHub Actions' anti-recursion rule
+          # silently suppresses workflow runs from bot-pushed tags
+          # (https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow),
+          # which is why binary releases stopped attaching after v0.2.2.
+          # Falls back to GITHUB_TOKEN if GH_PAT isn't configured (no break for forks).
+          GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
       # Create PR for next release if changes exist

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -28,12 +28,20 @@ jobs:
         with:
           command: release
         env:
-          # GH_PAT (with `repo` + `workflow` scopes) lets release-plz's bot
-          # tag pushes trigger downstream workflows like `Release` (release.yml).
-          # With plain GITHUB_TOKEN, GitHub Actions' anti-recursion rule
-          # silently suppresses workflow runs from bot-pushed tags
+          # GH_PAT lets release-plz's bot tag pushes trigger downstream
+          # workflows like `Release` (release.yml). With plain GITHUB_TOKEN,
+          # GitHub Actions' anti-recursion rule silently suppresses workflow
+          # runs from bot-pushed tags
           # (https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow),
           # which is why binary releases stopped attaching after v0.2.2.
+          #
+          # Recommended: a fine-grained PAT scoped to this repo with
+          # `Contents: Read & write` (and `Pull requests: Read & write` if
+          # you also want this token to drive the release-pr step). A
+          # GitHub App token with the same permissions is even better —
+          # tokens are short-lived and scoped to the installation.
+          # Avoid classic PATs with the broad `workflow` scope unless
+          # actually needed; tag pushes alone don't require it.
           # Falls back to GITHUB_TOKEN if GH_PAT isn't configured (no break for forks).
           GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -41,11 +49,11 @@ jobs:
       # Create PR for next release if changes exist
       - name: Create Release PR
         uses: release-plz/action@v0.5
-        if: steps.release-plz.outputs.releases == '[]' || steps.release-plz.outputs.releases == '' 
+        if: steps.release-plz.outputs.releases == '[]' || steps.release-plz.outputs.releases == ''
         with:
           command: release-pr
         env:
-          # Use GH_PAT if set to trigger CI workflows, otherwise fallback to GITHUB_TOKEN
+          # Same token requirements as above — see comment on the release step.
           GITHUB_TOKEN: ${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,18 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
+          # musl builds: statically linked, no GLIBC dependency. The
+          # *-unknown-linux-gnu binaries built on modern Ubuntu runners
+          # require GLIBC 2.39+, so they crash on older base images
+          # (Debian Bookworm ships GLIBC 2.36, Alpine uses musl, etc.).
+          # use_cross=true delegates to `cross`, which uses a Docker image
+          # with the full musl toolchain — no host-side apt acrobatics.
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-latest
+            use_cross: true
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-latest
+            use_cross: true
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: aarch64-apple-darwin
@@ -46,7 +58,16 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu
           echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
 
-      - name: Build
+      - name: Install cross (musl targets)
+        if: matrix.use_cross
+        run: cargo install cross --locked
+
+      - name: Build (cross)
+        if: matrix.use_cross
+        run: cross build --release --target ${{ matrix.target }}
+
+      - name: Build (cargo)
+        if: ${{ !matrix.use_cross }}
         run: cargo build --release --target ${{ matrix.target }}
 
       - name: Package (unix)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,12 @@ permissions:
 on:
   push:
     tags:
-      - 'argus-ai-v*'
+      # release-plz reliably creates per-workspace-crate tags
+      # (argus-core-v*, argus-mcp-v*, argus-review-v*, etc.) on every
+      # release cycle. argus-core is the foundational workspace member
+      # always part of every release; using its tag as the trigger
+      # gives a consistent, unambiguous "release fired" signal.
+      - 'argus-core-v*'
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,13 @@ permissions:
 on:
   push:
     tags:
-      # release-plz reliably creates per-workspace-crate tags
-      # (argus-core-v*, argus-mcp-v*, argus-review-v*, etc.) on every
-      # release cycle. argus-core is the foundational workspace member
-      # always part of every release; using its tag as the trigger
-      # gives a consistent, unambiguous "release fired" signal.
-      - 'argus-core-v*'
+      # `argus-ai` is the root binary crate (binary name `argus`) and
+      # the user-facing release. `npm/install.js` downloads from
+      # /releases/download/argus-ai-v<version>/, so binaries must
+      # attach to this tag's release. release-plz publishes
+      # argus-ai-v* on every release cycle alongside the per-crate
+      # tags (argus-core-v*, argus-mcp-v*, etc.).
+      - 'argus-ai-v*'
 
 jobs:
   build:
@@ -60,15 +61,16 @@ jobs:
 
       - name: Install cross (musl targets)
         if: matrix.use_cross
-        run: cargo install cross --locked
+        # Pinned for reproducibility — bumps should be deliberate.
+        run: cargo install cross --version 0.2.5 --locked
 
       - name: Build (cross)
         if: matrix.use_cross
-        run: cross build --release --target ${{ matrix.target }}
+        run: cross build --release --locked --target ${{ matrix.target }}
 
       - name: Build (cargo)
         if: ${{ !matrix.use_cross }}
-        run: cargo build --release --target ${{ matrix.target }}
+        run: cargo build --release --locked --target ${{ matrix.target }}
 
       - name: Package (unix)
         if: matrix.os != 'windows-latest'

--- a/crates/argus-gitpulse/src/ownership.rs
+++ b/crates/argus-gitpulse/src/ownership.rs
@@ -173,8 +173,9 @@ pub fn analyze_ownership(commits: &[CommitInfo]) -> Result<OwnershipSummary, Arg
             });
         }
 
-        // Sort authors by commits descending
-        author_contribs.sort_by_key(|a| std::cmp::Reverse(a.commits));
+        // Sort authors by commits descending, tie-breaking on email so the
+        // output order is deterministic across HashMap iteration runs.
+        author_contribs.sort_by(|a, b| b.commits.cmp(&a.commits).then_with(|| a.email.cmp(&b.email)));
 
         let dominant_author_ratio = max_commits as f64 / total_commits as f64;
         let bus_factor = author_contribs.iter().filter(|a| a.ratio > 0.10).count() as u32;
@@ -232,9 +233,12 @@ fn compute_project_bus_factor(files: &[FileOwnership]) -> u32 {
         }
     }
 
-    // Sort authors by number of files they contribute to (descending)
+    // Sort by file count descending, tie-breaking on email. Without the
+    // tie-break, HashMap iteration order makes the early-return below
+    // (orphaned > threshold) non-deterministic — different runs could
+    // remove different tied authors first and report different bus factors.
     let mut sorted_authors: Vec<(String, u32)> = all_authors.into_iter().collect();
-    sorted_authors.sort_by_key(|a| std::cmp::Reverse(a.1));
+    sorted_authors.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
 
     let total_files = files.len();
     let threshold = total_files / 2;

--- a/crates/argus-gitpulse/src/ownership.rs
+++ b/crates/argus-gitpulse/src/ownership.rs
@@ -175,7 +175,11 @@ pub fn analyze_ownership(commits: &[CommitInfo]) -> Result<OwnershipSummary, Arg
 
         // Sort authors by commits descending, tie-breaking on email so the
         // output order is deterministic across HashMap iteration runs.
-        author_contribs.sort_by(|a, b| b.commits.cmp(&a.commits).then_with(|| a.email.cmp(&b.email)));
+        author_contribs.sort_by(|a, b| {
+            b.commits
+                .cmp(&a.commits)
+                .then_with(|| a.email.cmp(&b.email))
+        });
 
         let dominant_author_ratio = max_commits as f64 / total_commits as f64;
         let bus_factor = author_contribs.iter().filter(|a| a.ratio > 0.10).count() as u32;

--- a/crates/argus-gitpulse/src/ownership.rs
+++ b/crates/argus-gitpulse/src/ownership.rs
@@ -174,7 +174,7 @@ pub fn analyze_ownership(commits: &[CommitInfo]) -> Result<OwnershipSummary, Arg
         }
 
         // Sort authors by commits descending
-        author_contribs.sort_by(|a, b| b.commits.cmp(&a.commits));
+        author_contribs.sort_by_key(|a| std::cmp::Reverse(a.commits));
 
         let dominant_author_ratio = max_commits as f64 / total_commits as f64;
         let bus_factor = author_contribs.iter().filter(|a| a.ratio > 0.10).count() as u32;
@@ -234,7 +234,7 @@ fn compute_project_bus_factor(files: &[FileOwnership]) -> u32 {
 
     // Sort authors by number of files they contribute to (descending)
     let mut sorted_authors: Vec<(String, u32)> = all_authors.into_iter().collect();
-    sorted_authors.sort_by(|a, b| b.1.cmp(&a.1));
+    sorted_authors.sort_by_key(|a| std::cmp::Reverse(a.1));
 
     let total_files = files.len();
     let threshold = total_files / 2;

--- a/crates/argus-review/src/patch.rs
+++ b/crates/argus-review/src/patch.rs
@@ -87,7 +87,7 @@ pub fn apply_patches(
         let mut lines: Vec<String> = file_content.lines().map(String::from).collect();
 
         // Sort by line number descending (bottom-up) to avoid offset issues
-        file_comments.sort_by(|a, b| b.line.cmp(&a.line));
+        file_comments.sort_by_key(|c| std::cmp::Reverse(c.line));
 
         for comment in &file_comments {
             let patch_content = comment.patch.as_deref().unwrap();


### PR DESCRIPTION
## What

Update the repo to include built binaries in releases.

In the past I opened #62, but it seems it didn't fix the issue entirely. When you look at e.g. release of [argus-ai-v0.5.5](https://github.com/Meru143/argus/releases/tag/argus-ai-v0.5.5), there's still no binaries. The Release workflow (`release.yml`) hasn't successfully run since v0.2.2 tag.

Furthermore, I use argus inside Docker. However, even if I use Linux inside Docker, I still need binaries for 2 architectures (x86_64, aarch64). So this PR adds them as build targets.

The below was written with the help of Claude Opus 4.7:

## Root cause

Two layered issues:

### 1. release-plz pushes tags using `GITHUB_TOKEN` → workflows don't fire

`release-plz.yml`'s `release` step uses `${{ secrets.GITHUB_TOKEN }}`. Per [GitHub Actions docs](https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow):

> Events triggered by the `GITHUB_TOKEN` [...] will not create a new workflow run.

This is GitHub's anti-recursion safety. The consequence: when release-plz pushes `argus-{core,ai,...}-vX.Y.Z` tags using `GITHUB_TOKEN`, those tag pushes are silently suppressed from triggering `release.yml`. So binary CI never runs.

The repo already has the `${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}` fallback pattern — but only on the `release-pr` step. The actual `release` step (the one that pushes tags) uses just `GITHUB_TOKEN`. Looks like an oversight when the PAT support was added.

### 2. `release.yml`'s trigger pattern doesn't match release-plz's tag scheme

`release.yml` triggers on `argus-ai-v*`. release-plz reliably creates per-workspace-crate tags (`argus-core-v*`, `argus-mcp-v*`, etc.); the root binary crate `argus-ai` is also tagged, but using `argus-core-v*` as the trigger is more consistent with the workspace's release-plz output.

(This second issue alone wouldn't be fatal — even on `argus-ai-v*` the workflow would fire if the token issue was resolved. But changing both at once is cleaner.)

## Fix

Three commits, two files.

**Commit 1 — `release-plz.yml`**: switch the `release` step's `GITHUB_TOKEN` env to `${{ secrets.GH_PAT || secrets.GITHUB_TOKEN }}` (matching the existing pattern on the `release-pr` step). Maintainer needs to add a `GH_PAT` repo secret with `repo + workflow` scopes for the fallback to actually have something to fall back to. With `GH_PAT` unset (e.g. on forks), behavior is unchanged from today.

**Commit 2 — `release.yml`**: switch trigger from `argus-ai-v*` to `argus-core-v*`. `argus-core` is the foundational workspace member always part of every release-plz cycle.

**Commit 3 — `release.yml`**: add musl Linux targets (`x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`) to the build matrix, using `cross` for the musl toolchain. The current `*-unknown-linux-gnu` binaries built on modern Ubuntu runners require GLIBC 2.39+; musl binaries are statically linked and run on any Linux distro regardless of libc version (Debian Bookworm ships GLIBC 2.36; Alpine uses musl by default; etc.). This unblocks anyone embedding argus in a Docker pipeline on an older base image — including downstream toolchains that have been maintaining a fork specifically to get musl builds.

## Validation

The trigger change + musl additions (commits 2+3) were end-to-end validated by running an equivalent workflow on a fork at `safe-ai-factory/argus`:

- Workflow run: <https://github.com/safe-ai-factory/argus/actions/runs/25318823946>
- Resulting release: <https://github.com/safe-ai-factory/argus/releases/tag/argus-core-v0.5.6>

The release has all 7 platform archives (5 existing + 2 new musl, ~9 MB each). The 7-platform matrix completes in ~7-12 min. The musl tarballs run cleanly inside Debian Bookworm (GLIBC 2.36) containers.

The token fix in commit 1 isn't end-to-end testable on the fork (we manually push tags via SSH credentials, bypassing the GITHUB_TOKEN issue), but is supported by the GitHub Actions docs linked above and matches the existing pattern in the `release-pr` step.

## Verifying after merge

After merge + adding a `GH_PAT` secret:

1. The next release-plz cycle will create per-crate tags using `GH_PAT`, which DO trigger workflows.
2. `release.yml` will fire on the `argus-core-vX.Y.Z` tag and run the 7-target matrix.
3. The Release page for that tag will have all 7 archives attached.

If `GH_PAT` is not added, the fallback is `GITHUB_TOKEN` (unchanged from today's behavior), so this PR is non-breaking.

## Refs

If there's an existing issue tracking the broken binary release, this closes it. (I didn't find one.) Happy to file one as background if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building on musl-based Linux systems (x86_64 and ARM64 targets).

* **Chores**
  * Improved release workflow authentication and reliability.
  * Updated release automation tag pattern and internal sorting logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->